### PR TITLE
Clarify GMAIL_PASSWD usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 
 # Your Gmail credentials
 GMAIL_EMAIL=youremail@gmail.com
+# Gmail App password
 GMAIL_PASSWD=your_app_password
 
 # Comma-separated senders we trust

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A robust, end-to-end pipeline to fetch video links from email, download media, t
 - Ubuntu Server 22+ (or macOS/Linux for development).
 - Python 3.10+ (for local/manual mode).
 - `ffmpeg` installed (needed by `yt-dlp` and Whisper).
-- Gmail App Password for IMAP access.
+- Gmail App Password for IMAP access (set as `GMAIL_PASSWD`).
 - Docker & Docker Compose recommended for reproducible environment.
 - Must be logged in to YouTube with Firefox for cookies export (see below).
 
@@ -46,7 +46,7 @@ A robust, end-to-end pipeline to fetch video links from email, download media, t
 		# Required in .env:
 		GMAIL_EMAIL=your@gmail.com
 		GMAIL_PASSWD=your_app_password
-		GMAIL_DESIRED_SENDERS=cspeakesinfo@gmail.com,thecspeakes@icloud.com
+                GMAIL_DESIRED_SENDERS=trusted1@example.com,trusted2@icloud.com
 		YTDLP_COOKIES_FILE=/app/cookies.txt
 
 	5. **Build and start the Docker service:**
@@ -90,7 +90,7 @@ A robust, end-to-end pipeline to fetch video links from email, download media, t
 
 		GMAIL_EMAIL=your@gmail.com
 		GMAIL_PASSWD=your_app_password
-		GMAIL_DESIRED_SENDERS=cspeakesinfo@gmail.com,thecspeakes@icloud.com
+                GMAIL_DESIRED_SENDERS=trusted1@example.com,trusted2@icloud.com
 		YTDLP_COOKIES_FILE=/app/cookies.txt
 		INTERVAL=3600
 		MAX_IMAP_RETRIES=3

--- a/email_video_runner.py
+++ b/email_video_runner.py
@@ -262,6 +262,7 @@ def parse_arguments():
     if not args.gmail_email:
         args.gmail_email = os.environ.get('GMAIL_EMAIL')
     if not args.gmail_passwd:
+        # Gmail App password via env var GMAIL_PASSWD
         args.gmail_passwd = os.environ.get('GMAIL_PASSWD')
 
     # Restore GMAIL_DESIRED_SENDERS logic:
@@ -271,7 +272,7 @@ def parse_arguments():
         args.approved_sender = [s.strip().lower() for s in re.split(r'[;,]', env_senders) if s.strip()]
     elif not args.approved_sender:
         # Fallback if nothing set anywhere
-        args.approved_sender = ['cspeakesinfo@gmail.com']
+        args.approved_sender = []
     else:
         # Already present via CLI, normalize
         args.approved_sender = [s.lower() for s in args.approved_sender]

--- a/send_factcheck_json_responses.py
+++ b/send_factcheck_json_responses.py
@@ -74,6 +74,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
     sender = get_env_var("GMAIL_EMAIL", required=True)
+    # Gmail App password stored in GMAIL_PASSWD
     password = get_env_var("GMAIL_PASSWD", required=True)
 
     fact_dirs = load_factcheck_dirs(args.list_path)


### PR DESCRIPTION
## Summary
- document GMAIL_PASSWD in `.env.example`
- mention GMAIL_PASSWD in prerequisites
- annotate Gmail password lookup in `email_video_runner.py`
- annotate Gmail password usage in `send_factcheck_json_responses.py`
- remove specific email example from docs and code

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68672c68bae483318634f0d7916d0e46