### PR TITLE
Add tmux runner for single pipeline run

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ A robust, end-to-end pipeline to fetch video links from email, download media, t
 
 ---
 
+## Ethical Use & Privacy
+
+- This project is intended for educational and lawful purposes. Only process content you have the right to access and share.
+- Downloads and transcripts may include personal data. Handle all files responsibly and remove them when no longer needed.
+- Keep your Gmail credentials and the `cookies.txt` export private. Do not commit them to version control; `.gitignore` already excludes `.env` and `cookies.txt`.
+
 ## Quick Start: Dockerized Setup (Recommended)
 
 	1. **Clone this repository:**
@@ -115,6 +121,13 @@ A robust, end-to-end pipeline to fetch video links from email, download media, t
 
 	Run everything on a loop (no cron needed):  
 		./run_pipeline.sh
+
+### One-Off Run via tmux
+
+        Start a single pipeline cycle in a detached tmux session:
+                ./tmux_run_once.sh [session_name]
+        Then attach with:
+                tmux attach -t [session_name]
 
 ### Docker Deployment
 

--- a/run_once_pipeline.sh
+++ b/run_once_pipeline.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# run_once_pipeline.sh
+# Run the email/video downloader and transcriber exactly once.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/venv"
+LOG_FILE="$SCRIPT_DIR/tell_me_truth.log"
+LOCK_FILE="$SCRIPT_DIR/tell_me_truth.lock"
+COOKIES_FILE="$SCRIPT_DIR/cookies.txt"
+
+# Activate virtual environment
+if [[ -f "$VENV_DIR/bin/activate" ]]; then
+    # shellcheck source=/dev/null
+    source "$VENV_DIR/bin/activate"
+else
+    echo "[x] Virtual environment not found at $VENV_DIR" | tee -a "$LOG_FILE"
+    exit 1
+fi
+
+# Ensure cookies file exists
+if [[ ! -f "$COOKIES_FILE" ]]; then
+    echo "[x] Cookies file not found: $COOKIES_FILE" | tee -a "$LOG_FILE"
+    exit 1
+fi
+export YTDLP_COOKIES_FILE="$COOKIES_FILE"
+
+# Obtain lock to prevent concurrent runs
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+    echo "[!] Another instance is already running. Exiting." | tee -a "$LOG_FILE"
+    exit 1
+fi
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] ==== Running single pipeline cycle ==== " | tee -a "$LOG_FILE"
+
+if python3 "$SCRIPT_DIR/email_video_runner.py" >> "$LOG_FILE" 2>&1; then
+    echo "[i] Video download stage completed successfully." | tee -a "$LOG_FILE"
+else
+    echo "[x] Video download stage failed." | tee -a "$LOG_FILE"
+fi
+
+if python3 "$SCRIPT_DIR/transcribe_downloaded_videos.py" >> "$LOG_FILE" 2>&1; then
+    echo "[i] Transcription stage completed successfully." | tee -a "$LOG_FILE"
+else
+    echo "[x] Transcription stage failed." | tee -a "$LOG_FILE"
+fi
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] ==== Single cycle complete ==== " | tee -a "$LOG_FILE"

--- a/tmux_run_once.sh
+++ b/tmux_run_once.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# tmux_run_once.sh
+# Launch run_once_pipeline.sh inside a tmux session for remote use.
+
+set -euo pipefail
+
+SESSION_NAME="${1:-tell_me_truth_once}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "[x] tmux is not installed. Please install it first." >&2
+    exit 1
+fi
+
+# Start new detached session running the pipeline once
+TMUX_CMD="bash \"$SCRIPT_DIR/run_once_pipeline.sh\""
+
+# shellcheck disable=SC2086
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    echo "[i] Session $SESSION_NAME already exists. Attaching..."
+    tmux attach -t "$SESSION_NAME"
+else
+    tmux new-session -d -s "$SESSION_NAME" "$TMUX_CMD"
+    echo "[i] Started tmux session '$SESSION_NAME'. Attach with: tmux attach -t $SESSION_NAME"
+fi


### PR DESCRIPTION
## Summary
- add `run_once_pipeline.sh` to execute a single download/transcribe cycle
- add `tmux_run_once.sh` for launching the single cycle in a tmux session
- document tmux one-off usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867376b38e88331acbb366d7150211e