### PR TITLE
Install gmailtail via git and enable git in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 # Install system dependencies (ffmpeg is required)
 RUN apt-get update && apt-get install -y \
     ffmpeg \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install Python dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ browser-cookie3>=0.18.3
 
 
 pytest>=8.0.0
+
+git+https://github.com/c4pt0r/gmailtail.git#egg=gmailtail


### PR DESCRIPTION
## Summary
- add `gmailtail` to `requirements.txt` from GitHub
- install `git` in the Docker image so the git-based dependency is fetched

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68673d8aae888331bdb6bda717decc34