### PR TITLE
Add OAuth mounts and clean up docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM python:3.10-slim
 # Set working directory
 WORKDIR /app
 
+# Default paths for Gmail OAuth files
+ENV GMAILTAIL_CREDENTIALS=/app/credentials.json \
+    GMAILTAIL_TOKEN=/app/token.json
+
 # Install system dependencies (ffmpeg is required)
 RUN apt-get update && apt-get install -y \
     ffmpeg \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A robust, end-to-end pipeline to fetch video links from email, download media, t
                 - In Google Cloud Console, enable the Gmail API and create an OAuth client ID (Desktop).
                 - Download the credentials JSON and save it as `credentials.json` in the project directory.
                 - Run `gmailtail --credentials credentials.json --token token.json --setup` and follow the browser flow.
+                - Keep both `credentials.json` and `token.json` in this folder so Docker can mount them.
 
         3. **Log into YouTube in Firefox (with the account you want to use).**
                 - Make sure you can play the restricted/private videos in your browser.
@@ -161,9 +162,9 @@ A robust, end-to-end pipeline to fetch video links from email, download media, t
 
 ## Project Structure
 
-	downloads/                          # Media and transcripts
-	email_video_runner.py               # IMAP fetch + media downloader
-	transcribe_downloaded_videos.py     # Whisper transcription
+        downloads/                          # Media and transcripts
+        email_video_runner.py               # Gmail fetch via gmailtail + media downloader
+        transcribe_downloaded_videos.py     # Whisper transcription
 	run_pipeline.sh                     # Master pipeline script
 	dump_firefox_cookies.py             # Generate cookies.txt from Firefox
 	requirements.txt                    # Python dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - ./:/app
       - ./cookies.txt:/app/cookies.txt:ro
+      - ./credentials.json:/app/credentials.json:ro
+      - ./token.json:/app/token.json:ro
       - ./tell_me_truth.log:/app/tell_me_truth.log
       - ./tell_me_truth.lock:/app/tell_me_truth.lock
 


### PR DESCRIPTION
## Summary
- mount Gmail OAuth credential files in docker-compose
- expose GMAILTAIL paths inside Dockerfile
- update README to note OAuth files and remove IMAP mention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686744e93f088331b6777d51e161fafc